### PR TITLE
Basic collision detection skeleton

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,6 +17,16 @@
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>2.0.2-beta</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/core/src/main/java/sem/group15/bubblebobble/core/BubbleBobble.java
+++ b/core/src/main/java/sem/group15/bubblebobble/core/BubbleBobble.java
@@ -8,6 +8,9 @@ import com.badlogic.gdx.Gdx;
 import sem.group15.bubblebobble.core.objects.PlayerObject;
 
 public class BubbleBobble implements ApplicationListener {
+	public static final int SPRITE_SIZE = 32;
+
+
 	LogicController controller;
 	SpriteBatch batch;
 

--- a/core/src/main/java/sem/group15/bubblebobble/core/LogicController.java
+++ b/core/src/main/java/sem/group15/bubblebobble/core/LogicController.java
@@ -39,7 +39,8 @@ public class LogicController {
     private void checkCollisions() {
         for(int i = 0; i < gameObjects.size() - 1; i++) {
             for(int i2 = i+1; i2 < gameObjects.size(); i2++) {
-                gameObjects.get(i).checkCollision(gameObjects.get(i2));
+                gameObjects.get(i).handleCollision(gameObjects.get(i2));
+                gameObjects.get(i2).handleCollision(gameObjects.get(i));
             }
         }
     }

--- a/core/src/main/java/sem/group15/bubblebobble/core/objects/BubbleObject.java
+++ b/core/src/main/java/sem/group15/bubblebobble/core/objects/BubbleObject.java
@@ -26,15 +26,6 @@ public class BubbleObject extends FloatingObject {
         ySpeed = 75;
     }
 
-    /**
-     * This methods checks if the bubble collides with another object.
-     * @param other Object that needs to be checked for a collision.
-     */
-
-    public  void checkCollision(GameObject other) {
-
-    }
-
 
     /**
      * This handles the collision for this bubble. It should only be used to update this object, not the other.
@@ -43,8 +34,7 @@ public class BubbleObject extends FloatingObject {
      * @param collided GameObject that collided with this. (only to be used to handle the collision correctly for this
      *                 GameObject.)
      */
-
-    protected  void handleCollision(GameObject collided) {
+    public void handleCollision(GameObject collided) {
         if (collided instanceof ImmutableObject) {
             // should not go through the immutableObject - stop y speed and go x speed untill objects don't collide.
         }

--- a/core/src/main/java/sem/group15/bubblebobble/core/objects/FilledBubbleObject.java
+++ b/core/src/main/java/sem/group15/bubblebobble/core/objects/FilledBubbleObject.java
@@ -29,21 +29,13 @@ public class FilledBubbleObject extends FloatingObject {
     }
 
     /**
-     * This methods checks if the bubble collides with another object.
-     * @param other Object that needs to be checked for a collision.
-     */
-    public  void checkCollision(GameObject other) {
-
-    }
-
-    /**
      * This handles the collision for this FilledBubbleObject. It should only be used to update this object, not the other.
      * If the FilledBubbleObject collides with an ImmutableObject, the y speed should change to 0 and the x speed should
      * change to either the right or left.
      * @param collided GameObject that collided with this. (only to be used to handle the collision correctly for this
      *                 GameObject.)
      */
-    protected  void handleCollision(GameObject collided) {
+    public  void handleCollision(GameObject collided) {
         if (collided instanceof ImmutableObject) {
             // should not go through the immutableObject - stop y speed and go x speed untill objects don't collide.
         }

--- a/core/src/main/java/sem/group15/bubblebobble/core/objects/FloorObject.java
+++ b/core/src/main/java/sem/group15/bubblebobble/core/objects/FloorObject.java
@@ -1,0 +1,38 @@
+package sem.group15.bubblebobble.core.objects;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Rectangle;
+import sem.group15.bubblebobble.core.BubbleBobble;
+
+/**
+ * Created by arjo on 8-9-15.
+ */
+public class FloorObject extends ImmutableObject {
+
+    public FloorObject(int locationX, int locationY) {
+        super(new Rectangle(locationX, locationY, BubbleBobble.SPRITE_SIZE, BubbleBobble.SPRITE_SIZE), new Texture(Gdx.files.internal("floor.png")));
+    }
+    public FloorObject(int locationX, int locationY, Texture texture) {
+        super(
+                new Rectangle(locationX, locationY, BubbleBobble.SPRITE_SIZE, BubbleBobble.SPRITE_SIZE),
+                texture
+        );
+    }
+
+    @Override
+    public void update(float elapsed) {
+
+    }
+
+    @Override
+    public void handleCollision(GameObject collided) {
+
+    }
+
+    @Override
+    public void draw(SpriteBatch spriteBatch) {
+        spriteBatch.draw(texture, location.x, location.y);
+    }
+}

--- a/core/src/main/java/sem/group15/bubblebobble/core/objects/GameObject.java
+++ b/core/src/main/java/sem/group15/bubblebobble/core/objects/GameObject.java
@@ -25,28 +25,19 @@ public abstract class GameObject {
     public abstract void update(float elapsed);
 
     /**
-     * Checks the List of all objects that are currently on screen for collisions. (Only checks collisions for GameObjects
-     * that are necessary for this GameObject.)
-     *
-     * TO THINK ABOUT: Possible to check all collisions only one way and then handle them for both objects. Probably by
-     * using int startingPoint in the LogicController. If a collision is found, this should call both this Objects'
-     * handleCollision method, and the collided object.
-     *
-     * ALSO: I'm not sure if this should happen in this object, or in the logicController. That might be a better place.
-     * @param other Object that needs to be checked for a collision.
-     */
-    public abstract void checkCollision(GameObject other);
-
-    /**
      * This handles the collision for this object. It should only be used to update this object, not the other.
      * @param collided GameObject that collided with this. (only to be used to handle the collision correctly for this
      *                 GameObject.)
      */
-    protected abstract void handleCollision(GameObject collided);
+    public abstract void handleCollision(GameObject collided);
 
     /**
      * This adds this sprite to the SpriteBatch, supplied by the LogicController.
      * @param spriteBatch SpriteBatch that the sprites need to be added to.
      */
     public abstract void draw(SpriteBatch spriteBatch);
+
+    public Rectangle getBody() {
+        return location;
+    }
 }

--- a/core/src/main/java/sem/group15/bubblebobble/core/objects/GravityObject.java
+++ b/core/src/main/java/sem/group15/bubblebobble/core/objects/GravityObject.java
@@ -7,6 +7,9 @@ import com.badlogic.gdx.math.Rectangle;
  * Created by arjo on 7-9-15.
  */
 public abstract class GravityObject extends GameObject {
+    private final int GRAVITY_SPEED = 100;
+    private final int MAX_GRAVITY_SPEED = -300;
+
 
     protected float timeSinceLastFloorContact;
 
@@ -20,14 +23,28 @@ public abstract class GravityObject extends GameObject {
         this.timeSinceLastFloorContact = 0;
     }
 
+    /**
+     * Updates the vertical speed. Just as real gravity, this is based on the time that has passed since last
+     * floorcontact. Also, there is a max speed.
+     * @param elapsed time elapsed since last gameloop.
+     */
     public void update(float elapsed) {
         timeSinceLastFloorContact += elapsed;
-        currentSpeedY = Math.max(currentSpeedY - (100 * timeSinceLastFloorContact * timeSinceLastFloorContact), -300);
+        currentSpeedY = Math.max(
+                currentSpeedY - (GRAVITY_SPEED * timeSinceLastFloorContact * timeSinceLastFloorContact),
+                MAX_GRAVITY_SPEED
+        );
     }
 
-    protected void handleCollision(GameObject other) {
-        if (other instanceof ImmutableObject) {
-
+    /**
+     *
+     * @param other
+     */
+    public void handleCollision(GameObject other) {
+        if (other instanceof FloorObject) {
+            if(location.overlaps(other.getBody()) && currentSpeedY < 0) {
+                location.y = other.getBody().getY() + other.getBody().getHeight();
+            }
         }
     }
 }

--- a/core/src/main/java/sem/group15/bubblebobble/core/objects/PlayerObject.java
+++ b/core/src/main/java/sem/group15/bubblebobble/core/objects/PlayerObject.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Rectangle;
+import sem.group15.bubblebobble.core.BubbleBobble;
 
 /**
  * Created by arjo on 7-9-15.
@@ -12,8 +13,18 @@ import com.badlogic.gdx.math.Rectangle;
 public class PlayerObject extends GravityObject {
 
     public PlayerObject(float xPosition, float yPosition) {
-        super(new Rectangle(32,32,xPosition,yPosition), new Texture(Gdx.files.internal("aqua-ball.png")));
+        super(
+                new Rectangle(xPosition,yPosition, BubbleBobble.SPRITE_SIZE,BubbleBobble.SPRITE_SIZE),
+                new Texture(Gdx.files.internal("aqua-ball.png"))
+        );
     }
+    public PlayerObject(float xPosition, float yPosition, Texture texture) {
+        super(
+                new Rectangle(xPosition,yPosition, BubbleBobble.SPRITE_SIZE,BubbleBobble.SPRITE_SIZE),
+                texture
+        );
+    }
+
 
     @Override
     public void update(float elapsed) {
@@ -35,16 +46,8 @@ public class PlayerObject extends GravityObject {
     }
 
     @Override
-    public void checkCollision(GameObject other) {
-
-    }
-
-    @Override
-    protected void handleCollision(GameObject other) {
+    public void handleCollision(GameObject other) {
         super.handleCollision(other);
-        if(other instanceof ImmutableObject) {
-
-        }
 
     }
 

--- a/core/src/test/java/sem/group15/bubblebobble/core/objects/GravityObjectTest.java
+++ b/core/src/test/java/sem/group15/bubblebobble/core/objects/GravityObjectTest.java
@@ -1,0 +1,39 @@
+package sem.group15.bubblebobble.core.objects;
+
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.graphics.GL20;
+import org.junit.Before;
+import org.junit.Test;
+import sem.group15.bubblebobble.core.BubbleBobble;
+import sem.group15.bubblebobble.core.LogicController;
+import static org.mockito.Mockito.*;
+
+import static org.junit.Assert.*;
+
+public class GravityObjectTest {
+
+    @Before
+    public void setUp() {
+        Gdx.app = mock(Application.class);
+        Gdx.input = mock(Input.class);
+    }
+
+    @Test
+    public void testHandleCollision() throws Exception {
+        GravityObject player = new PlayerObject(0,BubbleBobble.SPRITE_SIZE - 2, null);
+        FloorObject floor = new FloorObject(0,0, null);
+        player.update(0.1f);
+        player.handleCollision(floor);
+        assertEquals((float)BubbleBobble.SPRITE_SIZE,player.getBody().y, 0.01);
+    }
+
+    @Test
+    public void testHandleCollisionNoCollision() throws Exception {
+        GravityObject player = new PlayerObject(0,BubbleBobble.SPRITE_SIZE + 2, null);
+        FloorObject floor = new FloorObject(0,0, null);
+        player.handleCollision(floor);
+        assertEquals((float)BubbleBobble.SPRITE_SIZE + 2,player.getBody().y, 0.01);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+
+
 			<!-- core dependencies -->
 			<dependency>
 				<groupId>com.badlogicgames.gdx</groupId>
@@ -44,6 +46,7 @@
 				<classifier>natives-armeabi-v7a</classifier>
 				<scope>provided</scope>
 			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
* Fix bug that exchanged location and size of PlayerObject
* Remove checkCollision from all GameObjects.
* Add basic collision check between PlayerObject and FloorObject.
* Create FloorObject.
* Write simple test for HandleCollision by GravityObject.
* Add Mockito and JUnit to maven pom.